### PR TITLE
Cleanup some of the detection records

### DIFF
--- a/danger_zone/src/danger_zone.ruleset
+++ b/danger_zone/src/danger_zone.ruleset
@@ -25,6 +25,8 @@ const int32_t c_log_window_seconds = 30;
 const int32_t c_log_seconds_past = 5;
 const int32_t c_log_seconds_forward = c_log_window_seconds - c_log_seconds_past;
 
+const int32_t c_detection_cleanup_window_seconds = 3;
+
 using namespace gaia::danger_zone;
 
 ruleset objects_detection
@@ -76,6 +78,56 @@ ruleset objects_detection
         // so instead of using the current system time,
         // we'll use the time of the last detection as "current time".
         check_and_log(detection.seconds, detection.nanoseconds, c_log_window_seconds);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    /// Use the insertion of a detection to remove an old detection record.
+    /// A different rule with the same trigger is used to process unrelated actions.
+    ///
+    /// Triggered by:
+    ///   processing of detection messages in subscriber_node_t::detection3d_callback().
+    ///
+    /// Triggers:
+    ///   no other rules.
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    on_insert(detection)
+    {
+        // TODO: Simplify this proof-of-concept logic once the iteration bugs are fixed.
+        // Currently, this code only attempts to delete a detection at a time.
+        detection_loop:
+        for (/det:detection)
+        {
+            if (is_earlier(
+                det.seconds + c_detection_cleanup_window_seconds, det.nanoseconds,
+                detection.seconds, detection.nanoseconds))
+            {
+                // Before we can remove the detection record,
+                // we must disconnect and remove each detected object.
+                while (true)
+                {
+                    bool has_removed_object = false;
+
+                    object_loop:
+                    for (det->obj:d_object)
+                    {
+                        det.disconnect(obj);
+                        obj.remove();
+                        has_removed_object = true;
+                        break object_loop;
+                    }
+
+                    // If we're done processing all the detected objects,
+                    // then we can move on to deleting the detection record.
+                    if (!has_removed_object)
+                    {
+                        break;
+                    }
+                }
+
+                det.remove();
+                break detection_loop;
+            }
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This change shows how we could cleanup records for detections and their detected objects.

Unfortunately, due to the iterators not working well with deletions, I had to do some extra work to delete even a single detection record. But at least this worked on my machine and reduced the number of records that we keep around, so it's a good proof of concept. Once the bugs are fixed, this code could be simplified to remove a batch of detections at a time (by removing some of the breaks and booleans used now).